### PR TITLE
Change NI curl POSTs to GETs

### DIFF
--- a/number-insight/ni-advanced-async.sh
+++ b/number-insight/ni-advanced-async.sh
@@ -2,8 +2,4 @@
 
 source "../config.sh"
 
-curl -X "POST" "https://api.nexmo.com/ni/advanced/async/json" \
-     -d "api_key=$NEXMO_API_KEY" \
-     -d "api_secret=$NEXMO_API_SECRET" \
-     -d "number=$INSIGHT_NUMBER" \
-     -d "callback=$WEBHOOK_URL"
+curl "https://api.nexmo.com/ni/advanced/async/json?api_key=$NEXMO_API_KEY&api_secret=$NEXMO_API_SECRET&number=$INSIGHT_NUMBER&callback=$WEBHOOK_URL"

--- a/number-insight/ni-advanced.sh
+++ b/number-insight/ni-advanced.sh
@@ -2,7 +2,4 @@
 
 source "../config.sh"
 
-curl -X "POST" "https://api.nexmo.com/ni/advanced/json" \
-     -d "api_key=$NEXMO_API_KEY" \
-     -d "api_secret=$NEXMO_API_SECRET" \
-     -d "number=$INSIGHT_NUMBER"
+curl "https://api.nexmo.com/ni/advanced/json?api_key=$NEXMO_API_KEY&api_secret=$NEXMO_API_SECRET&number=$INSIGHT_NUMBER"

--- a/number-insight/ni-basic.sh
+++ b/number-insight/ni-basic.sh
@@ -2,7 +2,4 @@
 
 source "../config.sh"
 
-curl -X "POST" "https://api.nexmo.com/ni/basic/json" \
-     -d "api_key=$NEXMO_API_KEY" \
-     -d "api_secret=$NEXMO_API_SECRET" \
-     -d "number=$INSIGHT_NUMBER"
+curl "https://api.nexmo.com/ni/basic/json?api_key=$NEXMO_API_KEY&api_secret=$NEXMO_API_SECRET&number=$INSIGHT_NUMBER"

--- a/number-insight/ni-standard.sh
+++ b/number-insight/ni-standard.sh
@@ -2,7 +2,4 @@
 
 source "../config.sh"
 
-curl -X "POST" "https://api.nexmo.com/ni/standard/json" \
-     -d "api_key=$NEXMO_API_KEY" \
-     -d "api_secret=$NEXMO_API_SECRET" \
-     -d "number=$INSIGHT_NUMBER"
+curl "https://api.nexmo.com/ni/standard/json?api_key=$NEXMO_API_KEY&api_secret=$NEXMO_API_SECRET&number=$INSIGHT_NUMBER"


### PR DESCRIPTION
In discussion with JP Chenot and @lornajane, we decided that the `curl` code snippets were using the largely-unadvertised `POST` endpoints and they should use `GET` instead.