### PR TITLE
Add send binary SMS snippet

### DIFF
--- a/messaging/sms/send-binary-sms.sh
+++ b/messaging/sms/send-binary-sms.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+source "../../config.sh"
+
+curl -X "POST" "https://rest.nexmo.com/sms/json" \
+  -d "from=AcmeInc" \
+  -d "type=binary" \
+  -d "body=48656C6C6F21" \
+  -d "udh=0" \
+  -d "to=$TO_NUMBER" \
+  -d "api_key=$NEXMO_API_KEY" \
+  -d "api_secret=$NEXMO_API_SECRET"


### PR DESCRIPTION
Follows up on the suggestion in [DEVX-452](https://nexmoinc.atlassian.net/browse/DEVX-452).

The message is hex-encoded binary which reads `Hello!`. The message is sent OK, but is rejected by iOS and appears as `<<content not supported>>` on my son's Android phone. However, it seems to demonstrate that it's possible to send a binary message?