### PR TITLE
removing country code from snippet to align with spec

### DIFF
--- a/numbers/list-numbers.sh
+++ b/numbers/list-numbers.sh
@@ -2,4 +2,4 @@
 
 source "../config.sh"
 
-curl "https://rest.nexmo.com/account/numbers?api_key=$NEXMO_API_KEY&api_secret=$NEXMO_API_SECRET&country=$COUNTRY_CODE&pattern=$NUMBER_SEARCH_CRITERIA&search_pattern=$NUMBER_SEARCH_PATTERN"
+curl "https://rest.nexmo.com/account/numbers?api_key=$NEXMO_API_KEY&api_secret=$NEXMO_API_SECRET&pattern=$NUMBER_SEARCH_CRITERIA&search_pattern=$NUMBER_SEARCH_PATTERN"


### PR DESCRIPTION
Removing the country code field to align with spec:
https://github.com/Nexmo/code-snippet-specs/blob/master/numbers/list-owned-numbers.sh