### PR TITLE
Updated vbc authentication code snippet to include `vbc.prod` in username

### DIFF
--- a/vbc/authentication/password-grant.sh
+++ b/vbc/authentication/password-grant.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 source "../../config.sh"
 
-curl -k -d "grant_type=password&username=$VBC_USERNAME&password=$VBC_PASSWORD" \
+curl -k -d "grant_type=password&username=$VBC_USERNAME@vbc.prod&password=$VBC_PASSWORD" \
         -d "&client_id=$VBC_CLIENT_ID&client_secret=$VBC_CLIENT_SECRET" \
         https://api.vonage.com/token


### PR DESCRIPTION
When calling password_grant authentication, the domain `vbc.prod` needs to be appended to the username