### PR TITLE
Use template namespace and name

### DIFF
--- a/messages/whatsapp/send-button-link.sh
+++ b/messages/whatsapp/send-button-link.sh
@@ -22,8 +22,8 @@ curl -X POST \
       "custom": {
         "type": "template",
         "template": {
-          "namespace": "88b39973_f0d5_54e1_29cf_e80f1e3da4f2",
-          "name": "oculus_shipment_update",
+          "namespace": "'$WHATSAPP_TEMPLATE_NAMESPACE'",
+          "name": "'$WHATSAPP_TEMPLATE_NAME'",
           "language": {
             "code": "en",
             "policy": "deterministic"

--- a/messages/whatsapp/send-button-quick-reply.sh
+++ b/messages/whatsapp/send-button-quick-reply.sh
@@ -22,8 +22,8 @@ curl -X POST \
       "custom": {
         "type": "template",
         "template": {
-          "namespace": "88b39973_f0d5_54e1_29cf_e80f1e3da4f2",
-          "name": "upcoming_trip_reminder",
+          "namespace": "'$WHATSAPP_TEMPLATE_NAMESPACE'",
+          "name": "'$WHATSAPP_TEMPLATE_NAME'",
           "language": {
             "code": "en",
             "policy": "deterministic"

--- a/messages/whatsapp/send-media-mtm.sh
+++ b/messages/whatsapp/send-media-mtm.sh
@@ -22,8 +22,8 @@ curl -X POST \
       "custom": {
         "type": "template",
         "template": {
-          "namespace": "whatsapp:hsm:technology:nexmo",
-          "name": "parcel_location",
+          "namespace": "'$WHATSAPP_TEMPLATE_NAMESPACE'",
+          "name": "'$WHATSAPP_TEMPLATE_NAME'",
           "language": {
             "policy": "deterministic",
             "code": "en"

--- a/messages/whatsapp/send-mtm.sh
+++ b/messages/whatsapp/send-mtm.sh
@@ -20,7 +20,8 @@ curl -X POST \
       "content":{
          "type":"template",
          "template":{
-            "name":"WhatsApp_namespace:template_name",
+            "namespace": "'$WHATSAPP_TEMPLATE_NAMESPACE'",
+            "name":"'$WHATSAPP_TEMPLATE_NAME'",
             "parameters":[
                {
                   "default":"Nexmo Verification"


### PR DESCRIPTION
## Description

WhatsApp now does not allow you to send a message with a template created outside of your namespace. This means some of our code snippets will no longer work for customers using our Nexmo templates. To get around this only specify template namespace and template name variables. 