### PR TITLE
Add PSD2 feature code snippets for Verify API

### DIFF
--- a/verify/send-psd2-code-with-workflow.sh
+++ b/verify/send-psd2-code-with-workflow.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+source "../config.sh"
+
+curl -X GET "https://api.nexmo.com/verify/psd2/json?&api_key=$NEXMO_API_KEY&api_secret=$NEXMO_API_SECRET&number=$RECIPIENT_NUMBER&payee=AcmeInc&amount=12.34&workflow_id=$WORKFLOW_ID"

--- a/verify/send-psd2-code-with-workflow.sh
+++ b/verify/send-psd2-code-with-workflow.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 source "../config.sh"
 
-curl -X GET "https://api.nexmo.com/verify/psd2/json?&api_key=$NEXMO_API_KEY&api_secret=$NEXMO_API_SECRET&number=$RECIPIENT_NUMBER&payee=AcmeInc&amount=12.34&workflow_id=$WORKFLOW_ID"
+curl -X POST "https://api.nexmo.com/verify/psd2/json" -d api_key=$NEXMO_API_KEY -d api_secret=$NEXMO_API_SECRET -d number=$RECIPIENT_NUMBER -d payee=AcmeInc -d amount=12.34 -d workflow_id=$WORKFLOW_ID

--- a/verify/send-psd2-code.sh
+++ b/verify/send-psd2-code.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+source "../config.sh"
+
+curl -X GET "https://api.nexmo.com/verify/psd2/json?&api_key=$NEXMO_API_KEY&api_secret=$NEXMO_API_SECRET&number=$RECIPIENT_NUMBER&payee=AcmeInc&amount=12.34"

--- a/verify/send-psd2-code.sh
+++ b/verify/send-psd2-code.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 source "../config.sh"
 
-curl -X GET "https://api.nexmo.com/verify/psd2/json?&api_key=$NEXMO_API_KEY&api_secret=$NEXMO_API_SECRET&number=$RECIPIENT_NUMBER&payee=AcmeInc&amount=12.34"
+curl -X POST "https://api.nexmo.com/verify/psd2/json" -d api_key=$NEXMO_API_KEY -d api_secret=$NEXMO_API_SECRET -d number=$RECIPIENT_NUMBER -d payee=AcmeInc -d amount=12.34


### PR DESCRIPTION
We have a new feature in Verify API, these are the snippets for curl showing how to start a PSD2 verification (the check/cancel/etc endpoints are the same for all requests so we don't need new snippets)